### PR TITLE
Change CSV encoding from iso-8859-1 to utf-8

### DIFF
--- a/docassemble/103Divorce/data/sources/JDCs_by_Parish.csv
+++ b/docassemble/103Divorce/data/sources/JDCs_by_Parish.csv
@@ -21,7 +21,7 @@ East Feliciana Parish,20th,Samuel C. D'Aquilla
 Evangeline Parish,13th,Trent Brignac
 Franklin Parish,5th,Penny Douciere
 Grant Parish,35th,"James ""Jay"" P. Lemoine"
-Iberia Parish,16th,M. Bofill (Bo) Duhé
+Iberia Parish,16th,M. Bofill (Bo) DuhÃ©
 Iberville Parish,18th,Antonio M. Clayton
 Jackson Parish,2nd,Danny Newell
 Jefferson Parish,24th,"Paul D. Connick, Jr."
@@ -48,8 +48,8 @@ St. Helena Parish,21st,Scott M. Perrilloux
 St. James Parish,23rd,Ricky Babin
 St. John The Baptist Parish,40th,Bridget A. Dinvaut
 St. Landry Parish,27th,Chad P. Pitre
-St. Martin Parish,16th,M. Bofill (Bo) Duhé
-St. Mary Parish,16th,M. Bofill (Bo) Duhé
+St. Martin Parish,16th,M. Bofill (Bo) DuhÃ©
+St. Mary Parish,16th,M. Bofill (Bo) DuhÃ©
 St. Tammany Parish,22nd,Warren Montgomery
 Tangipahoa Parish,21st,Scott M. Perrilloux
 Tensas Parish,6th,James E. Paxton


### PR DESCRIPTION
utf-8 is a more standard encoding, 8859 is technically "western", but
apparently, pandas doesn't support reading it out of the box for some reason.