### PR TITLE
Efile proxy changes

### DIFF
--- a/docassemble/103Divorce/data/questions/interview.yml
+++ b/docassemble/103Divorce/data/questions/interview.yml
@@ -53,7 +53,7 @@ code: |
 code: |
   al_form_type = 'starts_case'
   efile_author_mode = False
-  proxy_conn = ProxyConnection(credentials_code_block=None)
+  proxy_conn = ProxyConnection(default_jurisdiction=jurisdiction_id, credentials_code_block=None)
 ---
 code: |
   jurisdiction_id = 'louisiana'
@@ -501,11 +501,18 @@ content: |
 code: |
   trial_court = court_list.as_court('trial_court', trial_court_index)
 ---
+depends on:
+  - trial_court
+code: |
+  court_id = convert_court_to_id(trial_court)
+  if court_id.endswith('parish'):
+    court_id = court_id[:-6].strip()
+---
 id: preview _Divorce_No_Children
 question: |
   Preview your form before you sign it
 subquestion: |
-  Here is a preview of the form you will sign on the next page.   
+  Here is a preview of the form you will sign on the next page.
   
   ${ al_court_bundle.as_pdf(key='preview') }
 

--- a/docassemble/103Divorce/data/sources/interview.feature
+++ b/docassemble/103Divorce/data/sources/interview.feature
@@ -1,0 +1,12 @@
+@interviews_start
+Feature: The interview runs without erroring
+
+These tests are made to work with the ALKiln testing framework, an automated testing framework made under the Document Assembly Line Project.
+
+Want to disable the tests? Want to learn more? See ALKiln's docs: https://suffolklitlab.github.io/docassemble-AssemblyLine-documentation/docs/automated_integrated_testing
+
+@divorce @start @fast
+Scenario: interview.yml runs
+  Given I start the interview at "interview.yml"
+
+@divorce 

--- a/docassemble/103Divorce/data/sources/interview.feature
+++ b/docassemble/103Divorce/data/sources/interview.feature
@@ -8,5 +8,3 @@ Want to disable the tests? Want to learn more? See ALKiln's docs: https://suffol
 @divorce @start @fast
 Scenario: interview.yml runs
   Given I start the interview at "interview.yml"
-
-@divorce 


### PR DESCRIPTION
Even though the Jefferson Parish e-filing isn't being used right now, this PR makes sure that everything will be ready and working with the newest version (i.e. "real") of the production e-filing server when e-filing is ready to go.